### PR TITLE
Support for loading static files from /<prefix>/static

### DIFF
--- a/pywb/apps/frontendapp.py
+++ b/pywb/apps/frontendapp.py
@@ -358,6 +358,9 @@ class FrontEndApp(object):
         try:
             endpoint, args = urls.match()
 
+            # store original script_name (original prefix) before modifications are made
+            environ['ORIG_SCRIPT_NAME'] = environ.get('SCRIPT_NAME')
+
             lang = args.pop('lang', '')
             if lang:
                 pop_path_info(environ)

--- a/pywb/apps/rewriterapp.py
+++ b/pywb/apps/rewriterapp.py
@@ -234,6 +234,8 @@ class RewriterApp(object):
 
         is_proxy = ('wsgiprox.proxy_host' in environ)
 
+        environ['pywb.host_prefix'] = host_prefix
+
         if self.use_js_obj_proxy:
             content_rw = self.js_proxy_rw
         else:

--- a/pywb/rewrite/templateview.py
+++ b/pywb/rewrite/templateview.py
@@ -139,7 +139,10 @@ class BaseInsertView(object):
         params = env.get(self.jenv.env_template_params_key)
         if params:
             kwargs.update(params)
+
         kwargs['env'] = env
+        kwargs['static_prefix'] = env.get('pywb.host_prefix', '') + env.get('ORIG_SCRIPT_NAME', '') + '/static'
+
 
         return template.render(**kwargs)
 

--- a/pywb/templates/banner.html
+++ b/pywb/templates/banner.html
@@ -1,4 +1,3 @@
 <!-- default banner, create through js -->
-<script src='{{ host_prefix }}/{{ static_path }}/default_banner.js'> </script>
-<link rel='stylesheet' href='{{ host_prefix }}/{{ static_path }}/default_banner.css'/>
-
+<script src='{{ static_prefix }}/default_banner.js'> </script>
+<link rel='stylesheet' href='{{ static_prefix }}/default_banner.css'/>

--- a/pywb/templates/frame_insert.html
+++ b/pywb/templates/frame_insert.html
@@ -12,7 +12,7 @@ html, body
 }
 
 </style>
-<script src='{{ host_prefix }}/{{ static_path }}/wb_frame.js'> </script>
+<script src='{{ static_prefix }}/wb_frame.js'> </script>
 
 {{ banner_html }}
 

--- a/pywb/templates/head_insert.html
+++ b/pywb/templates/head_insert.html
@@ -23,11 +23,11 @@
   wbinfo.is_live = {{ is_live }};
   wbinfo.coll = "{{ coll }}";
   wbinfo.proxy_magic = "{{ env.pywb_proxy_magic }}";
-  wbinfo.static_prefix = "{{ host_prefix }}/{{ static_path }}/";
+  wbinfo.static_prefix = "{{ static_prefix }}/";
 </script>
 
 {% if not wb_url.is_banner_only %}
-<script src='{{ host_prefix }}/{{ static_path }}/wombat.js'> </script>
+<script src='{{ static_prefix }}/wombat.js'> </script>
 <script>
   wbinfo.wombat_ts = "{{ wombat_ts }}";
   wbinfo.wombat_sec = "{{ wombat_sec }}";
@@ -51,7 +51,7 @@
 {% endif %}
 
 {% if config.enable_flash_video_rewrite %}
-<script src='{{ host_prefix }}/{{ static_path }}/vidrw.js'> </script>
+<script src='{{ static_prefix }}/vidrw.js'> </script>
 {% endif %}
 
 {{ banner_html }}

--- a/pywb/templates/query.html
+++ b/pywb/templates/query.html
@@ -1,12 +1,12 @@
 <html>
 <head>
 <!-- jquery and bootstrap dependencies query view -->
-<link rel="stylesheet" href="{{ host_prefix }}/{{ static_path }}/css/query.css">
-<link rel="stylesheet" href="{{ host_prefix }}/{{ static_path }}/css/bootstrap.min.css">
-<link rel="stylesheet" href="{{ host_prefix }}/{{ static_path }}/css/font-awesome.min.css">
-<script src="{{ host_prefix }}/{{ static_path }}/js/jquery-latest.min.js"></script>
-<script src="{{ host_prefix }}/{{ static_path }}/js/bootstrap.min.js"></script>
-<script src="{{ host_prefix }}/{{ static_path }}/query.js"></script>
+<link rel="stylesheet" href="{{ static_prefix }}/css/query.css">
+<link rel="stylesheet" href="{{ static_prefix }}/css/bootstrap.min.css">
+<link rel="stylesheet" href="{{ static_prefix }}/css/font-awesome.min.css">
+<script src="{{ static_prefix }}/js/jquery-latest.min.js"></script>
+<script src="{{ static_prefix }}/js/bootstrap.min.js"></script>
+<script src="{{ static_prefix }}/query.js"></script>
 </head>
 <body>
   <h2 class="text-center">pywb Query Results</h2>


### PR DESCRIPTION
static path prefix fix to support non-root pywb deployment:
- store original wsgi SCRIPT_NAME (before collection path is pushed)
- add 'static_prefix' jinja env global which defaults to original prefix + /static/
- update existing templates to use '{{ static_prefix }}' instead of '{{ host_prefix }}/{{ static_path }''
- set 'pywb.host_prefix' via rewriterapp, set 'static_prefix' to absolute url if available (to support proxy mode)

