### PR TITLE
LXML Parsing Fix

### DIFF
--- a/pywb/templates/banner.html
+++ b/pywb/templates/banner.html
@@ -2,3 +2,5 @@
 <!-- default banner, create through js -->
 <script src='{{ static_prefix }}/default_banner.js'> </script>
 <link rel='stylesheet' href='{{ static_prefix }}/default_banner.css'/>
+{% endif %}
+

--- a/pywb/utils/geventserver.py
+++ b/pywb/utils/geventserver.py
@@ -1,4 +1,4 @@
-from gevent.wsgi import WSGIServer, WSGIHandler
+from gevent.pywsgi import WSGIServer, WSGIHandler
 from gevent import spawn
 import logging
 

--- a/pywb/warcserver/index/indexsource.py
+++ b/pywb/warcserver/index/indexsource.py
@@ -237,7 +237,7 @@ class XmlQueryIndexSource(BaseIndexSource):
             response = self.session.get(query_url)
             response.raise_for_status()
 
-            results = etree.fromstring(response.text)
+            results = etree.fromstring(response.content)
 
             items = results.find('results')
 
@@ -248,7 +248,7 @@ class XmlQueryIndexSource(BaseIndexSource):
 
             raise NotFoundException('url {0} not found'.format(url))
 
-        if not items:
+        if len(items) == 0:
             raise NotFoundException('url {0} not found'.format(url))
 
         items = items.findall('result')

--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,7 @@ setup(
         'urllib3',
         'werkzeug',
         'httpbin==0.5.0',
+        'lxml',
        ],
     cmdclass={'test': PyTest},
     test_suite='',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->
Fixes parsing of XmlQueryIndexSource with lxml.
LXML parser doesn't accept unicode XML string if it contains an: `<?xml version="1.0" encoding="..."?>` declaration, so just pass the bytestring instead of unicode string to
XML parser.
(Also typo fix in banner.html, geventserver)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->
Attempt to fix part of ukwa/ukwa-pywb#38

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
