### PR TITLE
Timemap 404 / Fuzzy Matching Limit Fixes

### DIFF
--- a/pywb/apps/rewriterapp.py
+++ b/pywb/apps/rewriterapp.py
@@ -474,7 +474,7 @@ class RewriterApp(object):
 
             response = WbResponse.text_response(response, content_type=content_type)
 
-        if self.enable_memento:
+        if self.enable_memento and response.status_headers.statusline.startswith('200'):
             self._add_memento_links(wb_url.url, full_prefix, None, memento_ts,
                                     response.status_headers, is_timegate, is_proxy)
         return response

--- a/pywb/rules.yaml
+++ b/pywb/rules.yaml
@@ -1,5 +1,8 @@
 # Default Filters
 default_filters:
+    # limit to fuzzy match prefix results
+    fuzzy_search_limit: '100'
+
     # exts that should *not* be treated as files (ignore all query args)
     not_exts:
         - asp

--- a/pywb/templates/head_insert.html
+++ b/pywb/templates/head_insert.html
@@ -52,6 +52,10 @@
 <script src='{{ static_prefix }}/vidrw.js'> </script>
 {% endif %}
 
+{% if config.enable_transclusions %}
+<script src="{{ static_prefix }}/transclusions.js"> </script>
+{% endif %}
+
 {{ banner_html }}
 
 <!-- End WB Insert -->

--- a/pywb/warcserver/index/fuzzymatcher.py
+++ b/pywb/warcserver/index/fuzzymatcher.py
@@ -38,6 +38,8 @@ class FuzzyMatcher(object):
 
         self.default_filters = config.get('default_filters')
 
+        self.fuzzy_search_limit = self.default_filters.get('fuzzy_search_limit')
+
         self.url_normalize_rx = [(re.compile(rule['match']), rule['replace']) for rule in self.default_filters['url_normalize']]
 
     def parse_fuzzy_rule(self, rule):
@@ -120,6 +122,9 @@ class FuzzyMatcher(object):
                         'matchType': matched_rule.match_type,
                         'filter': filters,
                         'is_fuzzy': '1'}
+
+        if self.fuzzy_search_limit:
+            fuzzy_params['limit'] = self.fuzzy_search_limit
 
         for key in iterkeys(params):
             if key not in self.FUZZY_SKIP_PARAMS:

--- a/pywb/warcserver/index/test/test_fuzzymatcher.py
+++ b/pywb/warcserver/index/test/test_fuzzymatcher.py
@@ -12,6 +12,9 @@ class EchoParamsSource(BaseIndexSource):
         if params.get('matchType', 'exact') == 'exact':
             return iter([])
 
+        assert params.get('is_fuzzy') == '1'
+        assert params.get('limit') == '100'
+
         cdx = {'urlkey': canonicalize(params.get('cdx_url')),
                'mime': params.get('mime'),
                'filter': params.get('filter'),

--- a/tests/test_memento.py
+++ b/tests/test_memento.py
@@ -273,7 +273,25 @@ class TestMementoRedirectClassic(MementoMixin, BaseConfigTest):
         resp = self.testapp.get('/pywb/2/http://www.iana.org/', headers=headers)
         assert resp.status_code == 200
 
+        assert VARY not in resp.headers
+        assert MEMENTO_DATETIME in resp.headers
+
     def test_timegate_error_not_found(self):
         resp = self.testapp.get('/pywb/http://example.com/x-not-found', status=404)
         assert resp.status_code == 404
+
+        # No Memento Headers
+        assert VARY not in resp.headers
+        assert MEMENTO_DATETIME not in resp.headers
+        assert 'Link' not in resp.headers
+
+    def test_timemap_error_not_found(self):
+        resp = self.testapp.get('/pywb/timemap/link/http://example.com/x-not-found', status=404)
+        assert resp.status_code == 404
+
+        # No Memento Headers
+        assert VARY not in resp.headers
+        assert MEMENTO_DATETIME not in resp.headers
+        assert 'Link' not in resp.headers
+
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->
- Prevents memento headers from being included in 404 response for timemap (ukwa/ukwa-pywb#37)
- Optimization: limits fuzzy matching result sets to 100 to avoid large results from slowing down
(ukwa/ukwa-pywb#38)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests passed.
